### PR TITLE
Allow tags with underscores

### DIFF
--- a/_timew
+++ b/_timew
@@ -87,7 +87,7 @@ __timew_tags() {
 
     vals=$(sed '1,1d' ~/.timewarrior/data/tags.data | \
         sed '$d' | \
-        sed -E "s;^[[:space:]]+\"([[:space:][:alnum:]\.-_]+)\":.*$;\1;g")
+        sed -E "s;^[[:space:]]+\"([[:space:][:alnum:]\._-]+)\":.*$;\1;g")
 
     for i in ${(f)vals}; do arr+=$i; done
 

--- a/_timew
+++ b/_timew
@@ -87,7 +87,7 @@ __timew_tags() {
 
     vals=$(sed '1,1d' ~/.timewarrior/data/tags.data | \
         sed '$d' | \
-        sed -E "s;^[[:space:]]+\"([[:space:][:alnum:]\.-]+)\":.*$;\1;g")
+        sed -E "s;^[[:space:]]+\"([[:space:][:alnum:]\.-_]+)\":.*$;\1;g")
 
     for i in ${(f)vals}; do arr+=$i; done
 


### PR DESCRIPTION
Most of my tags container underscores instead of hyphens.
Tab completion where this is the case currently leads to auto-population of many escape characters on the CLI, e.g:

```
timew start \ \ \"some_tag\"
```

whereas it should show:

```
timew start some_tag
```

Including the `_` within the RegEx appears to resolve this issue. 