### PR TITLE
Add undo to zsh completion

### DIFF
--- a/_timew
+++ b/_timew
@@ -106,7 +106,6 @@ _commands=(
     'report:run an extension report'
     'resize:set interval duration'
     'retag:replace all tags in intervals'
-    'revert:revert Timewarrior commands'
     'shorten:shorten intervals'
     'show:display configuration'
     'split:split intervals'
@@ -116,6 +115,7 @@ _commands=(
     'tag:add tags to intervals'
     'tags:display a list of tags'
     'track:add intervals to the database'
+    'undo:revert the last Timewarrior command'
     'untag:remove tags from intervals'
     'week:shows a chart depicting a single week (current week by default)'
 )


### PR DESCRIPTION
Added the `undo` command to zsh completion, removed `revert` (which isn't a valid timewarrior command as of 1.8.0)