### PR TITLE
Respect $XDG_DATA_HOME if set

### DIFF
--- a/_timew
+++ b/_timew
@@ -6,8 +6,8 @@
 _timew() {
     local ret=1
 
-    if [ -d ${HOME}/.local/share/timewarrior/data ]; then
-        data_dir="${HOME}/.local/share/timewarrior/data"
+    if [ -d ${XDG_DATA_HOME:-${HOME}/.local/share}/timewarrior/data ]; then
+        data_dir="${XDG_DATA_HOME:-${HOME}/.local/share}/timewarrior/data"
     fi
 
     if [ -d ${HOME}/.timewarrior/data ]; then


### PR DESCRIPTION
Respect the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), which was adopted by Timewarrior in version 1.5.0, according to [the release notes](https://github.com/gothenburgbitfactory/timewarrior/blob/1072700d5811ef4105636cdea40f6045b492eac8/ChangeLog#L115).

This commit make the completion system look for the data directory in these three places (in that order):

    1. $XDG_DATA_HOME/timewarrior/data/
    2. $HOME/.local/share/timewarrior/data/
    3. $HOME/.timewarrior/data/

Directories 2 and 3 were always looked up, whereas the first one is new and prioritised.