### PR TITLE
Stop using the timewarrior database directly, use DOM references instead

### DIFF
--- a/_timew
+++ b/_timew
@@ -44,7 +44,7 @@ _timew() {
 
 		# iterated over the m tags of interval n
 		for m in {1..$m_tags}; do
-		    tag=$(timew get dom.tracked.${n}.tag.${m})
+		    tag=$(timew get dom.tracked.${n}.tag.${m} 2>/dev/null)
 		    interval_tags+=("$tag")
 		done
 		arr+="@${n}:${interval_tags[@]}"

--- a/_timew
+++ b/_timew
@@ -6,19 +6,6 @@
 _timew() {
     local ret=1
 
-    if [ -d ${XDG_DATA_HOME:-${HOME}/.local/share}/timewarrior/data ]; then
-        data_dir="${XDG_DATA_HOME:-${HOME}/.local/share}/timewarrior/data"
-    fi
-
-    if [ -d ${HOME}/.timewarrior/data ]; then
-        data_dir="${HOME}/.timewarrior/data"
-    fi
-
-    if (( !${+data_dir} )); then
-        echo "\nCould not find data directory"
-        return $ret
-    fi
-
     _arguments -C \
         '1:command:->commands' \
         '*:ids_tags_hints:->ids_tags_hints' && ret=0
@@ -28,32 +15,43 @@ _timew() {
             _describe 'commands' _commands
             ;;
         ids_tags_hints)
-            local arr
+	    local arr vals
 
-            arr=()
-
-            # collect all tag data
-            vals=$(sed '1,1d' $data_dir/tags.data | \
-                sed '$d' | \
-                sed -E "s;^[[:space:]]+\"([[:space:][:alnum:]\._-]+)\":.*$;\1;g")
+	    arr=()
+	    # collected all tags from the database
+	    vals=( "${(z)$(timew get dom.tracked.tags :all)}" )
 
             # add all of the tags to the output array
-            for i in ${(f)vals}; do arr+=$i; done
+            for i in ${vals[@]}; do
+		# strip out possible single double quotes from
+		# multi-word tags
+		arr+=( "$(echo $i | tr -d \" | tr -d \')" );
+	    done
 
-            # append the predefined hints to the end
+	    # collect interval ids and associated tags.
+
+	    # iterate over the last 9 intervals
+	    for n in {1..9}; do
+		interval_tags=()
+
+		# try and get the n-th interval tag count
+		m_tags=$(timew get dom.tracked.${n}.tag.count 2>/dev/null)
+
+		# if the interval wasn't found, exit loop
+		if (( $? == 255 )); then
+		    break
+		fi
+
+		# iterated over the m tags of interval n
+		for m in {1..$m_tags}; do
+		    tag=$(timew get dom.tracked.${n}.tag.${m})
+		    interval_tags+=("$tag")
+		done
+		arr+="@${n}:${interval_tags[@]}"
+	    done
+
+	    # append the predefined hints to the end
             arr+=( "${_hints[@]} ")
-
-
-            vals=$(cat ${data_dir}/*-*.data | tail -n 9 | sed -E "s/inc .+# //g")
-
-            typeset -i count
-            count=$(echo $vals | wc -l)
-
-            for i in ${(f)vals};
-            do
-                arr+="@${count}:${i}"
-                ((count--))
-            done
 
             _describe 'hints_tags_ids' arr
             ;;


### PR DESCRIPTION
Changes motivated by https://github.com/ianmkenney/timewarrior_zsh_completion/pull/6 and https://github.com/GothenburgBitFactory/timewarrior/issues/692. 

Will ~not~ still work with timewarrior once https://github.com/GothenburgBitFactory/timewarrior/pull/696 is merged. All deprecated instances of `dom.tracked.n.tag...` will ~probably~ eventually need to be changed to `dom.tracked.n.tags...`.